### PR TITLE
Binary builds

### DIFF
--- a/attic/onedrive-gui/srpm.sh
+++ b/attic/onedrive-gui/srpm.sh
@@ -3,4 +3,4 @@
 source ../../prelude.sh
 
 download-sources
-build-srpm
+build-srpm -bs

--- a/attic/python-mopidy-ytmusic/srpm.sh
+++ b/attic/python-mopidy-ytmusic/srpm.sh
@@ -2,4 +2,4 @@
 
 source ../../prelude.sh
 
-build-srpm
+build-srpm -bs

--- a/attic/starship/srpm.sh
+++ b/attic/starship/srpm.sh
@@ -4,4 +4,4 @@ source ../../prelude.sh
 
 set-gh-release-version starship/starship
 download-sources
-build-srpm
+build-srpm -bb

--- a/attic/viu/srpm.sh
+++ b/attic/viu/srpm.sh
@@ -4,4 +4,4 @@ source ../../prelude.sh
 
 set-gh-release-version atanunq/viu
 download-sources
-build-srpm
+build-srpm -bb

--- a/bin/build-srpm
+++ b/bin/build-srpm
@@ -9,4 +9,4 @@ spec="${spec:?}"
 rpmbuild \
   --define "_topdir ${topdir}" \
   --define "_srcrpmdir ${outdir}" \
-  -bs "${spec}"
+  "$@" "${spec}"

--- a/packages/python-mopidy-iris/srpm.sh
+++ b/packages/python-mopidy-iris/srpm.sh
@@ -2,4 +2,4 @@
 
 source ../../prelude.sh
 
-build-srpm
+build-srpm -bs

--- a/packages/python-mopidy-local/srpm.sh
+++ b/packages/python-mopidy-local/srpm.sh
@@ -2,4 +2,4 @@
 
 source ../../prelude.sh
 
-build-srpm
+build-srpm -bs

--- a/packages/python-sdbus/srpm.sh
+++ b/packages/python-sdbus/srpm.sh
@@ -2,4 +2,4 @@
 
 source ../../prelude.sh
 
-build-srpm
+build-srpm -bs

--- a/packages/yq/srpm.sh
+++ b/packages/yq/srpm.sh
@@ -4,4 +4,4 @@ source ../../prelude.sh
 
 set-gh-release-version mikefarah/yq
 download-sources
-build-srpm
+build-srpm -bb

--- a/templates/gh-release/{{cookiecutter.package}}/srpm.sh
+++ b/templates/gh-release/{{cookiecutter.package}}/srpm.sh
@@ -4,4 +4,4 @@ source ../../prelude.sh
 
 set-gh-release-version {{cookiecutter.gh_repository}}
 download-sources
-build-srpm
+build-srpm -bs

--- a/templates/pypi-custom/python-{{cookiecutter.package}}/srpm.sh
+++ b/templates/pypi-custom/python-{{cookiecutter.package}}/srpm.sh
@@ -2,4 +2,4 @@
 
 source ../../prelude.sh
 
-build-srpm
+build-srpm -bs


### PR DESCRIPTION
I currently have some packages where are intended to be binary builds.

I started trying out passing a different set of flags to rpmbuild, as in here:

<https://unix.stackexchange.com/questions/89364/how-can-i-build-a-rpm-for-i386-target-on-a-x86-64-machine>

However, that doesn't work.

I _suspect_ that COPR doesn't support binary builds, and that I'll need to refactor those builds to use source code. But pushing this branch here just in case.